### PR TITLE
Nest pipeline docs and add example configs page

### DIFF
--- a/docs/example_configs.md
+++ b/docs/example_configs.md
@@ -1,0 +1,67 @@
+# Example configs
+
+Complete pipeline YAML for each analysis mode, pulled live from the
+[`examples/`](https://github.com/lg345/XSpect/tree/master/examples) directory.
+Each one runs end to end with `Pipeline.from_yaml(...)`. Read the
+[YAML pipeline guide](YAML_PIPELINE_GUIDE.md) for the section-by-section
+reference and the [step reference](steps/index.md) for what each step does.
+
+## Static XES
+
+Single-state emission spectra, no time or energy axis. Loads the ePix, filters
+to x-ray shots, patches dead columns, rotates the dispersion axis, and sums to
+one spectrum per run. `examples/mfx101080524_static_xes.yaml`.
+
+```yaml
+--8<-- "examples/mfx101080524_static_xes.yaml"
+```
+
+## Time-resolved (pump-probe) XES
+
+Laser-on minus laser-off emission, binned by pump-probe delay. Adds
+`time_binning` and the laser masks, then `reduce_detector_temporal` and the
+`combine_runs` reduction to build the transient.
+`examples/mfxl1027922_ultrafast_xes.yaml`.
+
+```yaml
+--8<-- "examples/mfxl1027922_ultrafast_xes.yaml"
+```
+
+## 2D XAS (energy × delay)
+
+Simultaneous incident-energy scan and pump-probe delay, producing a transient
+absorption map Δμ(E, t). Uses `make_ccm_axis`, `ccm_binning`, `time_binning`,
+and `reduce_detector_ccm_temporal`. `examples/xcs101591326_2d_xas.yaml`.
+
+```yaml
+--8<-- "examples/xcs101591326_2d_xas.yaml"
+```
+
+## Temporal XAS
+
+Fluorescence-detected XAS at a fixed incident energy, scanned over delay
+(I_f / I_0). `examples/xcs101591326_temporal_xas.yaml`.
+
+```yaml
+--8<-- "examples/xcs101591326_temporal_xas.yaml"
+```
+
+## Droplet / photon-counting XES
+
+Per-shot XES from the MFX droplet2photon sparse layout. `droplet_reconstruction`
+rebuilds dense frames from photon positions before the usual XES chain.
+`examples/mfx101609126_droplet_pershot_xes.yaml`.
+
+```yaml
+--8<-- "examples/mfx101609126_droplet_pershot_xes.yaml"
+```
+
+## RIXS
+
+Incident-energy scan with 2D emission images, giving a RIXS plane (incident
+energy from DCCM, emission energy from the von Hamos spectrometer).
+`examples/mfx101609126_static_rixs.yaml`.
+
+```yaml
+--8<-- "examples/mfx101609126_static_rixs.yaml"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,21 +11,23 @@ not_in_nav: |
 nav:
   - Home: index.md
   - Overview: Overview.md
-  - YAML pipeline guide: YAML_PIPELINE_GUIDE.md
-  - Step reference:
-    - Overview: steps/index.md
-    - Loading & filtering: steps/loading_filtering.md
-    - Detector & spatial: steps/detector.md
-    - Binning: steps/binning.md
-    - Spectra & reductions: steps/spectra.md
-  - Examples:
+  - YAML pipeline:
+    - Guide: YAML_PIPELINE_GUIDE.md
+    - Example configs: example_configs.md
+    - Step reference:
+      - Overview: steps/index.md
+      - Loading & filtering: steps/loading_filtering.md
+      - Detector & spatial: steps/detector.md
+      - Binning: steps/binning.md
+      - Spectra & reductions: steps/spectra.md
+    - Source:
+      - Model: source_model.md
+      - Controller: source_controller.md
+      - Analysis steps: source_analysis.md
+  - Getting started:
     - XAS: Getting_started_XAS.md
     - XES: Getting_started_XES.md
     - Post-processing: Post_Processing.md
-  - Source (YAML pipeline):
-    - Model: source_model.md
-    - Controller: source_controller.md
-    - Analysis steps: source_analysis.md
   - Source (legacy):
     - XSpect_Analysis: XSpect_Analysis.md
     - XSpect_Controller: XSpect_Controller.md
@@ -48,7 +50,9 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      base_path: ["."]
+      check_paths: true
   - admonition
   - pymdownx.arithmatex:
       generic: true


### PR DESCRIPTION
## What changed

Restructures the nav so everything about the YAML pipeline lives under one
section, and adds a page showing the full config for each analysis mode.

New "YAML pipeline" nav section, with children:
- Guide (`YAML_PIPELINE_GUIDE.md`)
- Example configs (new)
- Step reference (Overview + four category pages)
- Source (Model / Controller / Analysis steps)

The old top-level "Step reference" and "Source (YAML pipeline)" sections are
folded in here. The notebook getting-started pages move to a "Getting started"
section (renamed from "Examples" to avoid clashing with the new configs page).

`docs/example_configs.md` embeds the six analysis-mode YAML files live via
pymdownx snippets, so the docs track the real files in `examples/`:
static XES, time-resolved XES, 2D XAS, temporal XAS, droplet XES, RIXS.

## Test

`mkdocs build` with `check_paths: true` on snippets passes, so every include
resolves; spot-checked the built page to confirm the YAML renders.